### PR TITLE
Fix devportal cloud init

### DIFF
--- a/terraform/modules/devportal/cloud_init.tmpl
+++ b/terraform/modules/devportal/cloud_init.tmpl
@@ -35,7 +35,7 @@ bootcmd:
     fi
   - |
     if [ -n "${ip_address}" ] && [ -n "${zone}" ]; then
-      echo "\n${ip_address} ${zone}\n" >> /etc/hosts
+      echo "\n${ip_address} acm.${zone}\n" >> /etc/hosts
     fi
 
 runcmd:


### PR DESCRIPTION
### Proposed changes

Fix devportal cloud init file to allow devportal to post to itself on port 81. 

### Checklist

