### PR TITLE
fix: pin minimum packer aws plugin version

### DIFF
--- a/packer/acm/aws/README.md
+++ b/packer/acm/aws/README.md
@@ -25,6 +25,12 @@ cp acm.pkrvars.hcl.example acm.pkrvars.hcl
 
 - Update the packer vars file.
 
+- Run packer init
+
+```shell
+   packer init .
+```
+
 - Run packer build
 
 ```shell

--- a/packer/acm/aws/ubuntu-aws-acm.pkr.hcl
+++ b/packer/acm/aws/ubuntu-aws-acm.pkr.hcl
@@ -82,15 +82,16 @@ source "amazon-ebs" "disk" {
     device_name           = "/dev/sda1"
     volume_size           = 20
   }
-  ami_name                  = local.ami_name
-  ami_regions               = var.destination_regions
-  instance_type             = var.build_instance_type
-  region                    = var.build_region
-  skip_region_validation    = true
-  source_ami                = data.amazon-ami.base_image.id
-  ssh_clear_authorized_keys = true
-  ssh_username              = "ubuntu"
-  subnet_id                 = var.subnet_id
+  ami_name                    = local.ami_name
+  ami_regions                 = var.destination_regions
+  instance_type               = var.build_instance_type
+  region                      = var.build_region
+  skip_region_validation      = true
+  source_ami                  = data.amazon-ami.base_image.id
+  ssh_clear_authorized_keys   = true
+  ssh_username                = "ubuntu"
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
 }
 
 build {

--- a/packer/agent/aws/README.md
+++ b/packer/agent/aws/README.md
@@ -24,6 +24,12 @@ AWS_SECURITY_TOKEN
 cp agent.pkrvars.hcl.example agent.pkrvars.hcl
 ```
 
+- Run packer init
+
+```shell
+   packer init .
+```
+
 - Run packer build
 
 ```shell

--- a/packer/agent/aws/ubuntu-aws-agent.pkr.hcl
+++ b/packer/agent/aws/ubuntu-aws-agent.pkr.hcl
@@ -76,15 +76,16 @@ source "amazon-ebs" "disk" {
     device_name           = "/dev/sda1"
     volume_size           = 20
   }
-  ami_name                  = local.ami_name
-  ami_regions               = var.destination_regions
-  instance_type             = var.build_instance_type
-  region                    = var.build_region
-  skip_region_validation    = true
-  source_ami                = data.amazon-ami.base_image.id
-  ssh_clear_authorized_keys = true
-  ssh_username              = "ubuntu"
-  subnet_id                 = var.subnet_id
+  ami_name                    = local.ami_name
+  ami_regions                 = var.destination_regions
+  instance_type               = var.build_instance_type
+  region                      = var.build_region
+  skip_region_validation      = true
+  source_ami                  = data.amazon-ami.base_image.id
+  ssh_clear_authorized_keys   = true
+  ssh_username                = "ubuntu"
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
 }
 
 build {

--- a/packer/devportal/aws/README.md
+++ b/packer/devportal/aws/README.md
@@ -23,6 +23,12 @@ AWS_SECURITY_TOKEN
 cp devportal.pkrvars.hcl.example devportal.pkrvars.hcl
 ```
 
+- Run packer init
+
+```shell
+   packer init .
+```
+
 - Run packer build
 
 ```shell

--- a/packer/devportal/aws/ubuntu-aws-devportal.pkr.hcl
+++ b/packer/devportal/aws/ubuntu-aws-devportal.pkr.hcl
@@ -87,15 +87,16 @@ source "amazon-ebs" "disk" {
     device_name           = "/dev/sda1"
     volume_size           = 20
   }
-  ami_name                  = local.ami_name
-  ami_regions               = var.destination_regions
-  instance_type             = var.build_instance_type
-  region                    = var.build_region
-  skip_region_validation    = true
-  source_ami                = data.amazon-ami.base_image.id
-  ssh_clear_authorized_keys = true
-  ssh_username              = "ubuntu"
-  subnet_id                 = var.subnet_id
+  ami_name                    = local.ami_name
+  ami_regions                 = var.destination_regions
+  instance_type               = var.build_instance_type
+  region                      = var.build_region
+  skip_region_validation      = true
+  source_ami                  = data.amazon-ami.base_image.id
+  ssh_clear_authorized_keys   = true
+  ssh_username                = "ubuntu"
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
 }
 
 build {


### PR DESCRIPTION
### Proposed changes

Pin to minimum aws plugin version to avoid issue where public ip's are not allocated in subnets with public ip allocation disabled

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nms-iac/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nms-iac/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nms-iac/blob/main/CHANGELOG.md))
