### PR TITLE
Fix name of NMS ACM variable for packer build

### DIFF
--- a/packer/nms/aws/README.md
+++ b/packer/nms/aws/README.md
@@ -39,17 +39,17 @@ cp nms.pkrvars.hcl.example nms.pkrvars.hcl
 
 ## Configuration
 
-| Parameter                        | Description                                                                                 | Default                         | Required |
-| -------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------- | -------- |
-| ami_name                         | _The name of the final AMI image_                                                           | `nms-ubuntu-20-04-<DD-MMM-YYYY` | No       |
-| base_ami_name                    | _The name of the base AMI image_                                                            | -                               | Yes      |
-| base_ami_owner_acct              | _The owner of the base AMI image_                                                           | -                               | Yes      |
-| build_instance_type              | _The instance type to use for building the image_                                           | `t3.micro`                      | No       |
-| build_region                     | _The region to build the image in_                                                          | `us-west-1`                     | No       |
-| destination_regions              | _The region or regions the image will be available in_                                      | `us-west-1`                     | No       |
-| nginx_management_suite_version   | _The version to use for installing NMS Api Connectivity Manager_                            | `1.7.0`                         | No       |
-| nms_app_delivery_manager_version | _The version to use for installing NMS App Delivery Manager_                                | `4.0.0`                         | No       |
-| nms_security_monitoring_version  | _The version to use for installing NMS Security Module_                                     | `1.5.0`                         | No       |
-| nginx_repo_cert                  | _Path to cert required to access the yum/deb repo for NMS_                                  | -                               | Yes      |
-| nginx_repo_key                   | _Path to key required to access the yum/deb repo for NMS_                                   | -                               | Yes      |
-| subnet_id                        | _ID of subnet for the image to be built in, will attempt to use the default VPC if not set_ | -                               | No       |
+| Parameter                            | Description                                                                                 | Default                          | Required |
+| ------------------------------------ | ------------------------------------------------------------------------------------------- | -------------------------------- | -------- |
+| ami_name                             | _The name of the final AMI image_                                                           | `nms-ubuntu-20-04-<DD-MMM-YYYY>` | No       |
+| base_ami_name                        | _The name of the base AMI image_                                                            | -                                | Yes      |
+| base_ami_owner_acct                  | _The owner of the base AMI image_                                                           | -                                | Yes      |
+| build_instance_type                  | _The instance type to use for building the image_                                           | `t3.micro`                       | No       |
+| build_region                         | _The region to build the image in_                                                          | `us-west-1`                      | No       |
+| destination_regions                  | _The region or regions the image will be available in_                                      | `us-west-1`                      | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_                            | `1.7.0`                          | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_                                | `4.0.0`                          | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_                                     | `1.5.0`                          | No       |
+| nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_                                  | -                                | Yes      |
+| nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_                                   | -                                | Yes      |
+| subnet_id                            | _ID of subnet for the image to be built in, will attempt to use the default VPC if not set_ | -                                | No       |

--- a/packer/nms/aws/nms.pkrvars.hcl.example
+++ b/packer/nms/aws/nms.pkrvars.hcl.example
@@ -5,7 +5,7 @@ build_region                             = "us-west-1"
 destination_regions                      = ["us-west-1"]
 nginx_repo_cert                          = "~/nginx-repo.crt"
 nginx_repo_key                           = "~/nginx-repo.key"
-nginx_management_suite_version           = "1.7.0"
+nms_api_connectivity_manager_version     = "1.7.0"
 nms_app_delivery_manager_version         = "4.0.0"
 nms_security_monitoring_version          = "1.4.0"
 

--- a/packer/nms/aws/ubuntu-aws-nms.pkr.hcl
+++ b/packer/nms/aws/ubuntu-aws-nms.pkr.hcl
@@ -55,7 +55,7 @@ variable "subnet_id" {
   default = null
 }
 
-variable "nginx_management_suite_version" {
+variable "nms_api_connectivity_manager_version" {
   type    = string
   default = "1.7.0"
 }
@@ -117,7 +117,7 @@ build {
   }
 
   provisioner "shell-local" {
-    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nginx_management_suite_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
+    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nms_api_connectivity_manager_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
   }
 
   provisioner "ansible" {

--- a/packer/nms/azure/README.md
+++ b/packer/nms/azure/README.md
@@ -50,16 +50,16 @@ cp nms.pkrvars.hcl.example nms.pkrvars.hcl
 
 ## Configuration
 
-| Parameter                        | Description                                                      | Default                                             | Required |
-| -------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------- | -------- |
-| base_image_offer                 | _The name of the base compute image_                             | -                                                   | Yes      |
-| base_image_publisher             | _The owner of the base compute image_                            | -                                                   | Yes      |
-| base_image_sku                   | _The sku of the base compute image_                              | -                                                   | Yes      |
-| build_instance_type              | _The instance type to use for building the image_                | `Standard_B1s`                                      | No       |
-| image_name                       | _The name of the final compute image_                            | `nms-ubuntu-20-04-<nginx_management_suite_version>` | No       |
-| nginx_management_suite_version   | _The version to use for installing NMS Api Connectivity Manager_ | `1.7.0`                                             | No       |
-| nms_app_delivery_manager_version | _The version to use for installing NMS App Delivery Manager_     | `4.0.0`                                             | No       |
-| nms_security_monitoring_version  | _The version to use for installing NMS Security Module_          | `1.5.0`                                             | No       |
-| nginx_repo_cert                  | _Path to cert required to access the yum/deb repo for NMS_       | -                                                   | Yes      |
-| nginx_repo_key                   | _Path to key required to access the yum/deb repo for NMS_        | -                                                   | Yes      |
-| resource_group_name              | _The resource group where the build and final image is located_  | -                                                   | Yes      |
+| Parameter                            | Description                                                      | Default                          | Required |
+| ------------------------------------ | ---------------------------------------------------------------- | -------------------------------- | -------- |
+| base_image_offer                     | _The name of the base compute image_                             | -                                | Yes      |
+| base_image_publisher                 | _The owner of the base compute image_                            | -                                | Yes      |
+| base_image_sku                       | _The sku of the base compute image_                              | -                                | Yes      |
+| build_instance_type                  | _The instance type to use for building the image_                | `Standard_B1s`                   | No       |
+| image_name                           | _The name of the final compute image_                            | `nms-ubuntu-20-04-<DD-MMM-YYYY>` | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_ | `1.7.0`                          | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_     | `4.0.0`                          | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_          | `1.5.0`                          | No       |
+| nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_       | -                                | Yes      |
+| nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_        | -                                | Yes      |
+| resource_group_name                  | _The resource group where the build and final image is located_  | -                                | Yes      |

--- a/packer/nms/azure/nms.pkrvars.hcl.example
+++ b/packer/nms/azure/nms.pkrvars.hcl.example
@@ -4,9 +4,9 @@ base_image_sku                       = "22_04-lts-gen2"
 build_instance_type                  = "Standard_B1s"
 nginx_repo_cert                      = "~/nginx-repo.crt"
 nginx_repo_key                       = "~/nginx-repo.key"
-nginx_management_suite_version       = "1.7.0"
+nms_api_connectivity_manager_version = "1.7.0"
 nms_app_delivery_manager_version     = "4.0.0"
 nms_security_monitoring_version      = "1.5.0"
 
-#image_name          = "my_image_name" # if not provided, defaults to nms-ubuntu-20-04-<nginx_management_suite_version>
+#image_name          = "my_image_name" # if not provided, defaults to nms-ubuntu-20-04-<nms_api_connectivity_manager_version>
 #resource_group_name = "my-resource_group_name"

--- a/packer/nms/azure/ubuntu-azure-nms.pkr.hcl
+++ b/packer/nms/azure/ubuntu-azure-nms.pkr.hcl
@@ -57,7 +57,7 @@ variable "nginx_repo_key" {
 }
 
 
-variable "nginx_management_suite_version" {
+variable "nms_api_connectivity_manager_version" {
   type    = string
   default = "1.7.0"
 }
@@ -108,7 +108,7 @@ build {
   }
 
   provisioner "shell-local" {
-    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nginx_management_suite_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
+    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nms_api_connectivity_manager_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
   }
 
   provisioner "ansible" {

--- a/packer/nms/gcp/README.md
+++ b/packer/nms/gcp/README.md
@@ -31,15 +31,15 @@ cp nms.pkrvars.hcl.example nms.pkrvars.hcl
 
 ## Configuration
 
-| Parameter                        | Description                                                      | Default                                             | Required |
-| -------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------- | -------- |
-| base_image_name                  | _The name of the base AMI image_                                 | `ubuntu-2204-jammy-v20230114`                       | No       |
-| build_zone                       | _The GCP zone to build the image in_                             | `europe-west4-a`                                    | No       |
-| build_instance_type              | _The instance type to use for building the image_                | `e2-micro`                                          | No       |
-| image_name                       | _The name of the final GCP image_                                | `nms-ubuntu-22-04-<nginx_management_suite_version>` | No       |
-| nginx_management_suite_version   | _The version to use for installing NMS Api Connectivity Manager_ | `1.7.0`                                             | No       |
-| nms_app_delivery_manager_version | _The version to use for installing NMS App Delivery Manager_     | `4.0.0`                                             | No       |
-| nms_security_monitoring_version  | _The version to use for installing NMS Security Module_          | `1.5.0`                                             | No       |
-| nginx_repo_cert                  | _Path to cert required to access the yum/deb repo for NMS_       | -                                                   | Yes      |
-| nginx_repo_key                   | _Path to key required to access the yum/deb repo for NMS_        | -                                                   | Yes      |
-| project_id                       | _GCP project id to use_                                          | -                                                   | Yes      |
+| Parameter                            | Description                                                      | Default                          | Required |
+| ------------------------------------ | ---------------------------------------------------------------- | -------------------------------- | -------- |
+| base_image_name                      | _The name of the base AMI image_                                 | `ubuntu-2204-jammy-v20230114`    | No       |
+| build_zone                           | _The GCP zone to build the image in_                             | `europe-west4-a`                 | No       |
+| build_instance_type                  | _The instance type to use for building the image_                | `e2-micro`                       | No       |
+| image_name                           | _The name of the final GCP image_                                | `nms-ubuntu-22-04-<DD-MMM-YYYY>` | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_ | `1.7.0`                          | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_     | `4.0.0`                          | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_          | `1.5.0`                          | No       |
+| nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_       | -                                | Yes      |
+| nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_        | -                                | Yes      |
+| project_id                           | _GCP project id to use_                                          | -                                | Yes      |

--- a/packer/nms/gcp/nms.pkrvars.hcl.example
+++ b/packer/nms/gcp/nms.pkrvars.hcl.example
@@ -3,9 +3,9 @@ build_zone                           = "europe-west4-a"
 build_instance_type                  = "e2-micro"
 nginx_repo_cert                      = "path_to_nginx_repo_cert"
 nginx_repo_key                       = "path_to_nginx_repo_key"
-nginx_management_suite_version       = "1.7.0"
+nms_api_connectivity_manager_version = "1.7.0"
 nms_app_delivery_manager_version     = "4.0.0"
 nms_security_monitoring_version      = "1.5.0"
 project_id                           = "myprojectid"
 
-#image_name                          = "target_image_name" # if not provided, defaults to nms-ubuntu-22-04-<nginx_management_suite_version>
+#image_name                          = "target_image_name" # if not provided, defaults to nms-ubuntu-22-04-<nms_api_connectivity_manager_version>

--- a/packer/nms/gcp/ubuntu-gcp-nms.pkr.hcl
+++ b/packer/nms/gcp/ubuntu-gcp-nms.pkr.hcl
@@ -32,7 +32,7 @@ variable "nginx_repo_key" {
   type = string
 }
 
-variable "nginx_management_suite_version" {
+variable "nms_api_connectivity_manager_version" {
   type    = string
   default = "1.7.0"
 }
@@ -79,7 +79,7 @@ build {
   }
 
   provisioner "shell-local" {
-    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nginx_management_suite_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
+    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nms_api_connectivity_manager_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
   }
 
   provisioner "ansible" {

--- a/packer/nms/vsphere/README.md
+++ b/packer/nms/vsphere/README.md
@@ -46,20 +46,20 @@ To overwrite a saved template use the `-force` flag.
 
 ## Configuration
 
-| Parameter                        | Description                                                                 | Default                                             | Required |
-| -------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
-| boot_command                     | _Boot command to run on machine_                                            |                                                     | No       |
-| cluster_name                     | _The vSphere cluster name_                                                  | -                                                   | Yes      |
-| datacenter                       | _The vSphere datacenter name_                                               | -                                                   | Yes      |
-| datastore                        | _The vSphere datastore name_                                                | -                                                   | Yes      |
-| template_name                    | _The name of the final vSphere template_                                    | `nms-ubuntu-22-04-<nginx_management_suite_version>` | No       |
-| iso_path                         | _Path to the desired ISO to use eg. ISO/ubuntu-22.04-live-server-amd64.iso_ | -                                                   | Yes      |
-| network                          | _The name of the vSphere network to place the template in_                  | -                                                   | Yes      |
-| nginx_management_suite_version   | _The version to use for installing NMS NGINX Management Suite_              | `1.7.0`                                             | No       |
-| nms_app_delivery_manager_version | _The version to use for installing NMS App Delivery Manager_                | `4.0.0`                                             | No       |
-| nms_security_monitoring_version  | _The version to use for installing NMS Security Module_                     | `1.5.0`                                             | No       |
-| nginx_repo_cert                  | _Path to cert required to access the yum/deb repo for NMS_                  | -                                                   | Yes      |
-| nginx_repo_key                   | _Path to key required to access the yum/deb repo for NMS_                   | -                                                   | Yes      |
-| vsphere_password                 | _The password of the executing vSphere user. _                              | Environment value                                   | No       |
-| vsphere_url                      | _The url of the vSphere API. _                                              | Environment value                                   | No       |
-| vsphere_username                 | _The name of the executing vSphere user._                                   | Environment value                                   | No       |
+| Parameter                            | Description                                                                 | Default                          | Required |
+| ------------------------------------ | --------------------------------------------------------------------------- | -------------------------------- | -------- |
+| boot_command                         | _Boot command to run on machine_                                            |                                  | No       |
+| cluster_name                         | _The vSphere cluster name_                                                  | -                                | Yes      |
+| datacenter                           | _The vSphere datacenter name_                                               | -                                | Yes      |
+| datastore                            | _The vSphere datastore name_                                                | -                                | Yes      |
+| template_name                        | _The name of the final vSphere template_                                    | `nms-ubuntu-22-04-<DD-MMM-YYYY>` | No       |
+| iso_path                             | _Path to the desired ISO to use eg. ISO/ubuntu-22.04-live-server-amd64.iso_ | -                                | Yes      |
+| network                              | _The name of the vSphere network to place the template in_                  | -                                | Yes      |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS NGINX Management Suite_              | `1.7.0`                          | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_                | `4.0.0`                          | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_                     | `1.5.0`                          | No       |
+| nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_                  | -                                | Yes      |
+| nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_                   | -                                | Yes      |
+| vsphere_password                     | _The password of the executing vSphere user. _                              | Environment value                | No       |
+| vsphere_url                          | _The url of the vSphere API. _                                              | Environment value                | No       |
+| vsphere_username                     | _The name of the executing vSphere user._                                   | Environment value                | No       |

--- a/packer/nms/vsphere/nms.pkrvars.hcl.example
+++ b/packer/nms/vsphere/nms.pkrvars.hcl.example
@@ -1,7 +1,7 @@
 
 nginx_repo_cert                        = "path_to_nginx_repo_cert"
 nginx_repo_key                         = "path_to_nginx_repo_key"
-nginx_management_suite_version         = "1.7.0"
+nms_api_connectivity_manager_version   = "1.7.0"
 nms_app_delivery_manager_version       = "4.0.0"
 nms_security_monitoring_version        = "1.5.0"
 iso_path                               = "ISO/ubuntu-22.04-live-server-amd64.iso"
@@ -14,4 +14,4 @@ network                                = "my_network"
 #vsphere_username                      = "my_username"
 #vsphere_password                      = "my_password"
 #vsphere_url                           = "my_vsphere_url"
-#template_name                         = "target_template_name" # if not provided, defaults to nms-ubuntu-22-04-<nginx_management_suite_version>
+#template_name                         = "target_template_name" # if not provided, defaults to nms-ubuntu-22-04-<nms_api_connectivity_manager_version>

--- a/packer/nms/vsphere/ubuntu-vsphere-nms.pkr.hcl
+++ b/packer/nms/vsphere/ubuntu-vsphere-nms.pkr.hcl
@@ -18,7 +18,7 @@ variable "nginx_repo_key" {
   type = string
 }
 
-variable "nginx_management_suite_version" {
+variable "nms_api_connectivity_manager_version" {
   type    = string
   default = "1.7.0"
 }
@@ -127,7 +127,7 @@ build {
   }
 
   provisioner "shell-local" {
-    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nginx_management_suite_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
+    inline = ["${path.root}/../../scripts/write_nms_ansible_group_vars.sh ${var.nginx_repo_cert} ${var.nginx_repo_key} ${var.nms_api_connectivity_manager_version} ${var.nms_app_delivery_manager_version} ${var.nms_security_monitoring_version}"]
   }
 
   provisioner "ansible" {


### PR DESCRIPTION
### Proposed changes

The variable name for acm was incorrectly named. This has been fixed.
The readme default value for the generated image/machine name was not correct accross all clouds/on prem solutions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nms-iac/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nms-iac/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nms-iac/blob/main/CHANGELOG.md))
