### PR TITLE
fix: remove default module versions so latest are used

### DIFF
--- a/packer/agent/aws/agent.pkrvars.hcl.example
+++ b/packer/agent/aws/agent.pkrvars.hcl.example
@@ -7,5 +7,5 @@ nginx_repo_cert = "~/nginx-repo.crt"
 nginx_repo_key = "~/nginx-repo.key"
 
 
-#ami_name = "my_ami_name" # if not provided, defaults to nginx-agent-ubuntu-20-04
+#ami_name = "my_ami_name" # if not provided, defaults to nginx-agent-<YYYY-MM-DD>
 #subnet_id = "my_subnet_id" # if not provided, defaults to in default vpc

--- a/packer/agent/aws/ubuntu-aws-agent.pkr.hcl
+++ b/packer/agent/aws/ubuntu-aws-agent.pkr.hcl
@@ -56,7 +56,8 @@ variable "subnet_id" {
 }
 
 locals {
-  ami_name = var.ami_name != null ? var.ami_name : "nginx-agent-ubuntu-20-04"
+  timestamp = formatdate("YYYY-MM-DD", timestamp())
+  ami_name  = var.ami_name != null ? var.ami_name : "nginx-agent-${local.timestamp}"
 }
 
 data "amazon-ami" "base_image" {

--- a/packer/nms/aws/README.md
+++ b/packer/nms/aws/README.md
@@ -41,15 +41,15 @@ cp nms.pkrvars.hcl.example nms.pkrvars.hcl
 
 | Parameter                            | Description                                                                                 | Default                          | Required |
 | ------------------------------------ | ------------------------------------------------------------------------------------------- | -------------------------------- | -------- |
-| ami_name                             | _The name of the final AMI image_                                                           | `nms-ubuntu-20-04-<DD-MMM-YYYY>` | No       |
+| ami_name                             | _The name of the final AMI image_                                                           | `nms-<YYYY-MM-DD>`               | No       |
 | base_ami_name                        | _The name of the base AMI image_                                                            | -                                | Yes      |
 | base_ami_owner_acct                  | _The owner of the base AMI image_                                                           | -                                | Yes      |
 | build_instance_type                  | _The instance type to use for building the image_                                           | `t3.micro`                       | No       |
 | build_region                         | _The region to build the image in_                                                          | `us-west-1`                      | No       |
 | destination_regions                  | _The region or regions the image will be available in_                                      | `us-west-1`                      | No       |
-| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_                            | `1.7.0`                          | No       |
-| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_                                | `4.0.0`                          | No       |
-| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_                                     | `1.5.0`                          | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_                            | `*`                              | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_                                | `*`                              | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_                                     | `*`                              | No       |
 | nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_                                  | -                                | Yes      |
 | nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_                                   | -                                | Yes      |
 | subnet_id                            | _ID of subnet for the image to be built in, will attempt to use the default VPC if not set_ | -                                | No       |

--- a/packer/nms/aws/nms.pkrvars.hcl.example
+++ b/packer/nms/aws/nms.pkrvars.hcl.example
@@ -5,10 +5,9 @@ build_region                             = "us-west-1"
 destination_regions                      = ["us-west-1"]
 nginx_repo_cert                          = "~/nginx-repo.crt"
 nginx_repo_key                           = "~/nginx-repo.key"
-nms_api_connectivity_manager_version     = "1.7.0"
-nms_app_delivery_manager_version         = "4.0.0"
-nms_security_monitoring_version          = "1.4.0"
 
-
+#nms_api_connectivity_manager_version    = "1.7.0"
+#nms_app_delivery_manager_version        = "4.0.0"
+#nms_security_monitoring_version         = "1.4.0"
 #ami_name                                = "my_ami_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
 #subnet_id                               = "my_subnet_id" # if not provided, defaults to in default vpc

--- a/packer/nms/aws/nms.pkrvars.hcl.example
+++ b/packer/nms/aws/nms.pkrvars.hcl.example
@@ -9,5 +9,5 @@ nginx_repo_key                           = "~/nginx-repo.key"
 #nms_api_connectivity_manager_version    = "1.7.0"
 #nms_app_delivery_manager_version        = "4.0.0"
 #nms_security_monitoring_version         = "1.4.0"
-#ami_name                                = "my_ami_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
+#ami_name                                = "my_ami_name" # if not provided, defaults to nms-<YYYY-MM-DD>
 #subnet_id                               = "my_subnet_id" # if not provided, defaults to in default vpc

--- a/packer/nms/aws/nms.pkrvars.hcl.example
+++ b/packer/nms/aws/nms.pkrvars.hcl.example
@@ -8,6 +8,6 @@ nginx_repo_key                           = "~/nginx-repo.key"
 
 #nms_api_connectivity_manager_version    = "1.7.0"
 #nms_app_delivery_manager_version        = "4.0.0"
-#nms_security_monitoring_version         = "1.4.0"
+#nms_security_monitoring_version         = "1.5.0"
 #ami_name                                = "my_ami_name" # if not provided, defaults to nms-<YYYY-MM-DD>
 #subnet_id                               = "my_subnet_id" # if not provided, defaults to in default vpc

--- a/packer/nms/aws/ubuntu-aws-nms.pkr.hcl
+++ b/packer/nms/aws/ubuntu-aws-nms.pkr.hcl
@@ -71,8 +71,8 @@ variable "nms_security_monitoring_version" {
 }
 
 locals {
-  timestamp = formatdate("DD-MMM-YY", timestamp())
-  ami_name  = var.ami_name != null ? var.ami_name : "nms-ubuntu-22-04-${local.timestamp}"
+  timestamp = formatdate("YYYY-MM-DD", timestamp())
+  ami_name  = var.ami_name != null ? var.ami_name : "nms-${local.timestamp}"
 }
 
 data "amazon-ami" "base_image" {

--- a/packer/nms/aws/ubuntu-aws-nms.pkr.hcl
+++ b/packer/nms/aws/ubuntu-aws-nms.pkr.hcl
@@ -57,17 +57,17 @@ variable "subnet_id" {
 
 variable "nms_api_connectivity_manager_version" {
   type    = string
-  default = "1.7.0"
+  default = ""
 }
 
 variable "nms_app_delivery_manager_version" {
   type    = string
-  default = "4.0.0"
+  default = ""
 }
 
 variable "nms_security_monitoring_version" {
   type    = string
-  default = "1.5.0"
+  default = ""
 }
 
 locals {

--- a/packer/nms/azure/README.md
+++ b/packer/nms/azure/README.md
@@ -56,10 +56,10 @@ cp nms.pkrvars.hcl.example nms.pkrvars.hcl
 | base_image_publisher                 | _The owner of the base compute image_                            | -                                | Yes      |
 | base_image_sku                       | _The sku of the base compute image_                              | -                                | Yes      |
 | build_instance_type                  | _The instance type to use for building the image_                | `Standard_B1s`                   | No       |
-| image_name                           | _The name of the final compute image_                            | `nms-ubuntu-20-04-<DD-MMM-YYYY>` | No       |
-| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_ | `1.7.0`                          | No       |
-| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_     | `4.0.0`                          | No       |
-| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_          | `1.5.0`                          | No       |
+| image_name                           | _The name of the final compute image_                            | `nms-<YYYY-MM-DD>`               | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_ | `*`                              | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_     | `*`                              | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_          | `*`                              | No       |
 | nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_       | -                                | Yes      |
 | nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_        | -                                | Yes      |
 | resource_group_name                  | _The resource group where the build and final image is located_  | -                                | Yes      |

--- a/packer/nms/azure/nms.pkrvars.hcl.example
+++ b/packer/nms/azure/nms.pkrvars.hcl.example
@@ -7,6 +7,6 @@ nginx_repo_key                        = "~/nginx-repo.key"
 
 #nms_api_connectivity_manager_version = "1.7.0"
 #nms_app_delivery_manager_version     = "4.0.0"
-#nms_security_monitoring_version      = "1.4.0"
+#nms_security_monitoring_version      = "1.5.0"
 #image_name                           = "my_image_name" # if not provided, defaults to nms-<YYYY-MM-DD>
 #resource_group_name                  = "my-resource_group_name"

--- a/packer/nms/azure/nms.pkrvars.hcl.example
+++ b/packer/nms/azure/nms.pkrvars.hcl.example
@@ -8,5 +8,5 @@ nginx_repo_key                        = "~/nginx-repo.key"
 #nms_api_connectivity_manager_version = "1.7.0"
 #nms_app_delivery_manager_version     = "4.0.0"
 #nms_security_monitoring_version      = "1.4.0"
-#image_name                           = "my_image_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
+#image_name                           = "my_image_name" # if not provided, defaults to nms-<YYYY-MM-DD>
 #resource_group_name                  = "my-resource_group_name"

--- a/packer/nms/azure/nms.pkrvars.hcl.example
+++ b/packer/nms/azure/nms.pkrvars.hcl.example
@@ -1,12 +1,12 @@
-base_image_offer                     = "0001-com-ubuntu-server-jammy"
-base_image_publisher                 = "Canonical"
-base_image_sku                       = "22_04-lts-gen2"
-build_instance_type                  = "Standard_B1s"
-nginx_repo_cert                      = "~/nginx-repo.crt"
-nginx_repo_key                       = "~/nginx-repo.key"
-nms_api_connectivity_manager_version = "1.7.0"
-nms_app_delivery_manager_version     = "4.0.0"
-nms_security_monitoring_version      = "1.5.0"
+base_image_offer                      = "0001-com-ubuntu-server-jammy"
+base_image_publisher                  = "Canonical"
+base_image_sku                        = "22_04-lts-gen2"
+build_instance_type                   = "Standard_B1s"
+nginx_repo_cert                       = "~/nginx-repo.crt"
+nginx_repo_key                        = "~/nginx-repo.key"
 
-#image_name          = "my_image_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
-#resource_group_name = "my-resource_group_name"
+#nms_api_connectivity_manager_version = "1.7.0"
+#nms_app_delivery_manager_version     = "4.0.0"
+#nms_security_monitoring_version      = "1.4.0"
+#image_name                           = "my_image_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
+#resource_group_name                  = "my-resource_group_name"

--- a/packer/nms/azure/ubuntu-azure-nms.pkr.hcl
+++ b/packer/nms/azure/ubuntu-azure-nms.pkr.hcl
@@ -74,8 +74,8 @@ variable "nms_security_monitoring_version" {
 }
 
 locals {
-  timestamp = formatdate("DD-MMM-YY", timestamp())
-  image_name = var.image_name != null ? var.image_name : "nms-ubuntu-22-04-${local.timestamp}"
+  timestamp = formatdate("YYYY-MM-DD", timestamp())
+  image_name = var.image_name != null ? var.image_name : "nms-${local.timestamp}"
 }
 
 source "azure-arm" "ubuntu" {

--- a/packer/nms/azure/ubuntu-azure-nms.pkr.hcl
+++ b/packer/nms/azure/ubuntu-azure-nms.pkr.hcl
@@ -59,18 +59,18 @@ variable "nginx_repo_key" {
 
 variable "nms_api_connectivity_manager_version" {
   type    = string
-  default = "1.7.0"
+  default = ""
 }
 
 variable "nms_app_delivery_manager_version" {
   type    = string
-  default = "4.0.0"
+  default = ""
 }
 
 
 variable "nms_security_monitoring_version" {
   type    = string
-  default = "1.5.0"
+  default = ""
 }
 
 locals {

--- a/packer/nms/gcp/README.md
+++ b/packer/nms/gcp/README.md
@@ -36,10 +36,10 @@ cp nms.pkrvars.hcl.example nms.pkrvars.hcl
 | base_image_name                      | _The name of the base AMI image_                                 | `ubuntu-2204-jammy-v20230114`    | No       |
 | build_zone                           | _The GCP zone to build the image in_                             | `europe-west4-a`                 | No       |
 | build_instance_type                  | _The instance type to use for building the image_                | `e2-micro`                       | No       |
-| image_name                           | _The name of the final GCP image_                                | `nms-ubuntu-22-04-<DD-MMM-YYYY>` | No       |
-| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_ | `1.7.0`                          | No       |
-| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_     | `4.0.0`                          | No       |
-| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_          | `1.5.0`                          | No       |
+| image_name                           | _The name of the final GCP image_                                | `nms-<YYYY-MM-DD>`               | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS Api Connectivity Manager_ | `*`                              | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_     | `*`                              | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_          | `*`                              | No       |
 | nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_       | -                                | Yes      |
 | nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_        | -                                | Yes      |
 | project_id                           | _GCP project id to use_                                          | -                                | Yes      |

--- a/packer/nms/gcp/nms.pkrvars.hcl.example
+++ b/packer/nms/gcp/nms.pkrvars.hcl.example
@@ -3,9 +3,9 @@ build_zone                           = "europe-west4-a"
 build_instance_type                  = "e2-micro"
 nginx_repo_cert                      = "path_to_nginx_repo_cert"
 nginx_repo_key                       = "path_to_nginx_repo_key"
-nms_api_connectivity_manager_version = "1.7.0"
-nms_app_delivery_manager_version     = "4.0.0"
-nms_security_monitoring_version      = "1.5.0"
 project_id                           = "myprojectid"
 
-#image_name                          = "target_image_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
+#nms_api_connectivity_manager_version = "1.7.0"
+#nms_app_delivery_manager_version     = "4.0.0"
+#nms_security_monitoring_version      = "1.4.0"
+#image_name                           = "target_image_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>

--- a/packer/nms/gcp/nms.pkrvars.hcl.example
+++ b/packer/nms/gcp/nms.pkrvars.hcl.example
@@ -8,4 +8,4 @@ project_id                           = "myprojectid"
 #nms_api_connectivity_manager_version = "1.7.0"
 #nms_app_delivery_manager_version     = "4.0.0"
 #nms_security_monitoring_version      = "1.4.0"
-#image_name                           = "target_image_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
+#image_name                           = "target_image_name" # if not provided, defaults to nms-<YYYY-MM-DD>

--- a/packer/nms/gcp/nms.pkrvars.hcl.example
+++ b/packer/nms/gcp/nms.pkrvars.hcl.example
@@ -7,5 +7,5 @@ project_id                           = "myprojectid"
 
 #nms_api_connectivity_manager_version = "1.7.0"
 #nms_app_delivery_manager_version     = "4.0.0"
-#nms_security_monitoring_version      = "1.4.0"
+#nms_security_monitoring_version      = "1.5.0"
 #image_name                           = "target_image_name" # if not provided, defaults to nms-<YYYY-MM-DD>

--- a/packer/nms/gcp/ubuntu-gcp-nms.pkr.hcl
+++ b/packer/nms/gcp/ubuntu-gcp-nms.pkr.hcl
@@ -52,8 +52,8 @@ variable "project_id" {
 }
 
 locals {
-  timestamp = lower(formatdate("DD-MMM-YY", timestamp()))
-  image_name = var.image_name != null ? var.image_name : "nms-ubuntu-22-04-${local.timestamp}"
+  timestamp = lower(formatdate("YYYY-MM-DD", timestamp()))
+  image_name = var.image_name != null ? var.image_name : "nms-${local.timestamp}"
 }
 
 source "googlecompute" "gcp_disk" {

--- a/packer/nms/gcp/ubuntu-gcp-nms.pkr.hcl
+++ b/packer/nms/gcp/ubuntu-gcp-nms.pkr.hcl
@@ -34,17 +34,17 @@ variable "nginx_repo_key" {
 
 variable "nms_api_connectivity_manager_version" {
   type    = string
-  default = "1.7.0"
+  default = ""
 }
 
 variable "nms_app_delivery_manager_version" {
   type    = string
-  default = "4.0.0"
+  default = ""
 }
 
 variable "nms_security_monitoring_version" {
   type    = string
-  default = "1.5.0"
+  default = ""
 }
 
 variable "project_id" {

--- a/packer/nms/vsphere/README.md
+++ b/packer/nms/vsphere/README.md
@@ -52,12 +52,12 @@ To overwrite a saved template use the `-force` flag.
 | cluster_name                         | _The vSphere cluster name_                                                  | -                                | Yes      |
 | datacenter                           | _The vSphere datacenter name_                                               | -                                | Yes      |
 | datastore                            | _The vSphere datastore name_                                                | -                                | Yes      |
-| template_name                        | _The name of the final vSphere template_                                    | `nms-ubuntu-22-04-<DD-MMM-YYYY>` | No       |
+| template_name                        | _The name of the final vSphere template_                                    | `nms-<YYYY-MM-DD>`               | No       |
 | iso_path                             | _Path to the desired ISO to use eg. ISO/ubuntu-22.04-live-server-amd64.iso_ | -                                | Yes      |
 | network                              | _The name of the vSphere network to place the template in_                  | -                                | Yes      |
-| nms_api_connectivity_manager_version | _The version to use for installing NMS NGINX Management Suite_              | `1.7.0`                          | No       |
-| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_                | `4.0.0`                          | No       |
-| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_                     | `1.5.0`                          | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS NGINX Management Suite_              | `*`                              | No       |
+| nms_app_delivery_manager_version     | _The version to use for installing NMS App Delivery Manager_                | `*`                              | No       |
+| nms_security_monitoring_version      | _The version to use for installing NMS Security Module_                     | `*`                              | No       |
 | nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_                  | -                                | Yes      |
 | nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_                   | -                                | Yes      |
 | vsphere_password                     | _The password of the executing vSphere user. _                              | Environment value                | No       |

--- a/packer/nms/vsphere/nms.pkrvars.hcl.example
+++ b/packer/nms/vsphere/nms.pkrvars.hcl.example
@@ -1,16 +1,16 @@
 
 nginx_repo_cert                        = "path_to_nginx_repo_cert"
 nginx_repo_key                         = "path_to_nginx_repo_key"
-nms_api_connectivity_manager_version   = "1.7.0"
-nms_app_delivery_manager_version       = "4.0.0"
-nms_security_monitoring_version        = "1.5.0"
 iso_path                               = "ISO/ubuntu-22.04-live-server-amd64.iso"
 boot_command                           = "c<wait>linux /casper/vmlinuz --- autoinstall<enter><wait>initrd /casper/initrd <enter><wait>boot<enter>"
 cluster_name                           = "my_cluster_name"
 datacenter                             = "target_datacenter"
 datastore                              = "my_datastore"
 network                                = "my_network"
-  
+
+#nms_api_connectivity_manager_version  = "1.7.0"
+#nms_app_delivery_manager_version      = "4.0.0"
+#nms_security_monitoring_version       = "1.4.0"
 #vsphere_username                      = "my_username"
 #vsphere_password                      = "my_password"
 #vsphere_url                           = "my_vsphere_url"

--- a/packer/nms/vsphere/nms.pkrvars.hcl.example
+++ b/packer/nms/vsphere/nms.pkrvars.hcl.example
@@ -14,4 +14,4 @@ network                                = "my_network"
 #vsphere_username                      = "my_username"
 #vsphere_password                      = "my_password"
 #vsphere_url                           = "my_vsphere_url"
-#template_name                         = "target_template_name" # if not provided, defaults to nms-ubuntu-20-04-<DD-MMM-YYYY>
+#template_name                         = "target_template_name" # if not provided, defaults to nms-<YYYY-MM-DD>

--- a/packer/nms/vsphere/nms.pkrvars.hcl.example
+++ b/packer/nms/vsphere/nms.pkrvars.hcl.example
@@ -10,7 +10,7 @@ network                                = "my_network"
 
 #nms_api_connectivity_manager_version  = "1.7.0"
 #nms_app_delivery_manager_version      = "4.0.0"
-#nms_security_monitoring_version       = "1.4.0"
+#nms_security_monitoring_version       = "1.5.0"
 #vsphere_username                      = "my_username"
 #vsphere_password                      = "my_password"
 #vsphere_url                           = "my_vsphere_url"

--- a/packer/nms/vsphere/nms.pkrvars.hcl.example
+++ b/packer/nms/vsphere/nms.pkrvars.hcl.example
@@ -11,7 +11,4 @@ network                                = "my_network"
 #nms_api_connectivity_manager_version  = "1.7.0"
 #nms_app_delivery_manager_version      = "4.0.0"
 #nms_security_monitoring_version       = "1.5.0"
-#vsphere_username                      = "my_username"
-#vsphere_password                      = "my_password"
-#vsphere_url                           = "my_vsphere_url"
 #template_name                         = "target_template_name" # if not provided, defaults to nms-<YYYY-MM-DD>

--- a/packer/nms/vsphere/ubuntu-vsphere-nms.pkr.hcl
+++ b/packer/nms/vsphere/ubuntu-vsphere-nms.pkr.hcl
@@ -20,17 +20,17 @@ variable "nginx_repo_key" {
 
 variable "nms_api_connectivity_manager_version" {
   type    = string
-  default = "1.7.0"
+  default = ""
 }
 
 variable "nms_app_delivery_manager_version" {
   type    = string
-  default = "4.0.0"
+  default = ""
 }
 
 variable "nms_security_monitoring_version" {
   type    = string
-  default = "1.5.0"
+  default = ""
 }
 
 variable "cluster_name" {

--- a/packer/nms/vsphere/ubuntu-vsphere-nms.pkr.hcl
+++ b/packer/nms/vsphere/ubuntu-vsphere-nms.pkr.hcl
@@ -82,8 +82,9 @@ variable "template_name" {
 }
 
 locals {
+  timestamp = lower(formatdate("YYYY-MM-DD", timestamp()))
   console_password = var.console_password != null ? var.console_password : "ubuntu"
-  template_name = var.template_name != null ? var.template_name : "nms-ubuntu-22-04-${local.timestamp}"
+  template_name = var.template_name != null ? var.template_name : "nms-${local.timestamp}"
 }
 
 source "vsphere-iso" "ubuntu" {

--- a/terraform/standalone/nms/aws/main.tf
+++ b/terraform/standalone/nms/aws/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.16"
+      version = ">= 5.0.0"
     }
   }
 

--- a/terraform/standalone/nms/aws/terraform.tfvars.example
+++ b/terraform/standalone/nms/aws/terraform.tfvars.example
@@ -2,6 +2,6 @@ admin_user           = "admin"
 ami_id               = "my_ami_name"
 aws_region           = "us-west-1"
 ssh_pub_key          = "~/.ssh/id_rsa.pub"
-imcoming_cidr_blocks = ["x.x.x.x/32"]
+incoming_cidr_blocks = ["x.x.x.x/32"]
 
 #subnet_id    = "my_subnet_id"


### PR DESCRIPTION
### Proposed changes

Remove default module versions so the latest are always used, unless the user chooses a specific version

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nms-iac/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nms-iac/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nms-iac/blob/main/CHANGELOG.md))
