### PR TITLE
Add ssm-agent to redhat images

### DIFF
--- a/packer/nms/aws/nms.pkr.hcl
+++ b/packer/nms/aws/nms.pkr.hcl
@@ -129,7 +129,7 @@ build {
   }
 
   provisioner "shell" {
-    scripts = ["${path.root}/../../scripts/required-setup-all.sh"]
+    scripts = ["${path.root}/../../scripts/required-setup-all.sh", "${path.root}/../../scripts/aws-add-ssm.sh"]
   }
 
   post-processor "manifest" {

--- a/packer/scripts/aws-add-ssm.sh
+++ b/packer/scripts/aws-add-ssm.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Copyright (c) F5, Inc.
+#
+# This source code is licensed under the Apache License, Version 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+set -exo pipefail
+
+sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+sudo systemctl enable amazon-ssm-agent

--- a/packer/scripts/aws-add-ssm.sh
+++ b/packer/scripts/aws-add-ssm.sh
@@ -6,5 +6,10 @@
 # LICENSE file in the root directory of this source tree.
 set -exo pipefail
 
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-sudo systemctl enable amazon-ssm-agent
+
+source /etc/os-release
+
+if [ "${ID_LIKE}" != "debian" ]; then
+    sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+    sudo systemctl enable amazon-ssm-agent
+fi

--- a/packer/scripts/img-prep.sh
+++ b/packer/scripts/img-prep.sh
@@ -4,6 +4,7 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
+set -exo pipefail
 
 source /etc/os-release
 


### PR DESCRIPTION
### Proposed changes

Redhat AMIs do not come with ssm pre-installed. Add step to install it in packer.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nms-iac/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nms-iac/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nms-iac/blob/main/CHANGELOG.md))
