### PR TITLE
Nms to nim rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
-# NGINX Management Suite Infrastructure
+# NGINX Instance Manager Infrastructure
 
-This repo contains instructions that can be used to generate images using the [NGINX Management Suite Ansible role](https://github.com/nginxinc/ansible-role-nginx-management-suite) and [NGINX Ansible role](https://github.com/nginxinc/ansible-role-nginx). It also provides example infrastructure to deploy those images with Terraform using best practice security configuration.
+This repo contains instructions that can be used to generate images using the [NGINX Instance Manager Ansible role](https://github.com/nginxinc/ansible-role-nginx-management-suite) and [NGINX Ansible role](https://github.com/nginxinc/ansible-role-nginx). It also provides example infrastructure to deploy those images with Terraform using best practice security configuration.
 
 - [Image generation using packer](packer/README.md)
 - [Infrastructure Deployments using terraform](terraform/README.md)

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,11 +1,11 @@
-# NGINX Management Suite Image Generation
+# NGINX Instance Manager Image Generation
 
-This repo contains the templates and scripts that can be used to generate a NGINX Management Suite Control Host image.
+This repo contains the templates and scripts that can be used to generate a NGINX Instance Manager Control Host image.
 
 ## Requirements
 
 - Linux build environment, e.g. ubuntu-22.04
-- An NGINX Management Suite repo cert and key. This can be downloaded from [my.f5.com](my.f5.com).
+- An NGINX Instance Manager repo cert and key. This can be downloaded from [my.f5.com](my.f5.com).
 - [ansible >= 6.7.0](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 - Install sshpass (Debian based platforms only)
 - [packer >= 1.8](https://developer.hashicorp.com/packer/downloads)
@@ -25,8 +25,8 @@ This repo contains the templates and scripts that can be used to generate a NGIN
 
 Follow the README in the relevant directory to create images/machines.
 
-- [NGINX Management Suite Control Host AWS](nms/aws/README.md)
-- [NGINX Management Suite Control Host GCP](nms/gcp/README.md)
-- [NGINX Management Suite Control Host Azure](nms/azure/README.md)
-- [NGINX Management Suite Control Host vSphere](nms/vsphere/README.md)
+- [NGINX Instance Manager Control Host AWS](nms/aws/README.md)
+- [NGINX Instance Manager Control Host GCP](nms/gcp/README.md)
+- [NGINX Instance Manager Control Host Azure](nms/azure/README.md)
+- [NGINX Instance Manager Control Host vSphere](nms/vsphere/README.md)
 - [NGINX AWS](nginx/aws/README.md)

--- a/packer/nms/aws/README.md
+++ b/packer/nms/aws/README.md
@@ -1,6 +1,6 @@
-# NGINX Management Suite Control Host Image Generation for AWS
+# NGINX Instance Manager Control Host Image Generation for AWS
 
-This directory contains templates and scripts to create an NGINX Management Suite Ubuntu image to be deployable to AWS
+This directory contains templates and scripts to create an NGINX Instance Manager Ubuntu image to be deployable to AWS
 
 ## Requirements
 

--- a/packer/nms/azure/README.md
+++ b/packer/nms/azure/README.md
@@ -1,6 +1,6 @@
-# NGINX Management Suite Control Host Image Generation for Azure
+# NGINX Instance Manager Control Host Image Generation for Azure
 
-This directory contains templates and scripts to create an NGINX Management Suite Ubuntu image to be deployable to Azure
+This directory contains templates and scripts to create an NGINX Instance Manager Ubuntu image to be deployable to Azure
 
 ## Requirements
 

--- a/packer/nms/gcp/README.md
+++ b/packer/nms/gcp/README.md
@@ -1,6 +1,6 @@
-# NGINX Management Suite Control Host Image Generation for GCP
+# NGINX Instance Manager Control Host Image Generation for GCP
 
-This directory contains templates and scripts to create an NGINX Management Suite Ubuntu image to be deployable to GCP
+This directory contains templates and scripts to create an NGINX Instance Manager Ubuntu image to be deployable to GCP
 
 ## Requirements
 

--- a/packer/nms/vsphere/README.md
+++ b/packer/nms/vsphere/README.md
@@ -1,6 +1,6 @@
-# NGINX Management Suite Control Host Template Generation for vSphere
+# NGINX Instance Manager Control Host Template Generation for vSphere
 
-This directory contains templates and scripts to create an NGINX Management Suite Ubuntu template to be deployable to VSphere
+This directory contains templates and scripts to create an NGINX Instance Manager Ubuntu template to be deployable to VSphere
 
 ## Requirements
 
@@ -61,7 +61,7 @@ To overwrite a saved template use the `-force` flag.
 | template_name                        | _The name of the final vSphere template_                                    | `nms-<YYYY-MM-DD>`               | No       |
 | iso_path                             | _Path to the desired ISO to use eg. ISO/ubuntu-22.04-live-server-amd64.iso_ | -                                | Yes      |
 | network                              | _The name of the vSphere network to place the template in_                  | -                                | Yes      |
-| nms_api_connectivity_manager_version | _The version to use for installing NMS NGINX Management Suite_              | `*`                              | No       |
+| nms_api_connectivity_manager_version | _The version to use for installing NMS NGINX Instance Manager_              | `*`                              | No       |
 | nms_security_monitoring_version      | _The version to use for installing NMS Security Module_                     | `*`                              | No       |
 | nginx_repo_cert                      | _Path to cert required to access the yum/deb repo for NMS_                  | -                                | Yes      |
 | nginx_repo_key                       | _Path to key required to access the yum/deb repo for NMS_                   | -                                | Yes      |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,12 +1,12 @@
-# NGINX Management Suite Image Deployment
+# NGINX Instance Manager Image Deployment
 
-This repo contains the templates and scripts that can be used to deploy an NGINX Management Suite image.
+This repo contains the templates and scripts that can be used to deploy an NGINX Instance Manager image.
 
 ## Requirements
 
 - Linux build environment, e.g. ubuntu-22.04
 - You must have generated the appropriate cloud images/machines using our [packer guide](../packer/README.md).
-- An NGINX Management Suite license. This can be downloaded from [my.f5.com](my.f5.com).
+- An NGINX Instance Manager license. This can be downloaded from [my.f5.com](my.f5.com).
 - [Terraform >= 1.2](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 - curl >= 7.68
 - jq >= 1.6

--- a/terraform/basic-reference/aws/README.md
+++ b/terraform/basic-reference/aws/README.md
@@ -1,6 +1,6 @@
-# AWS NGINX Management Suite Basic Reference Architecture
+# AWS NGINX Instance Manager Basic Reference Architecture
 
-This directory contains templates and scripts to deploy an NGINX Management Suite Ubuntu image to AWS
+This directory contains templates and scripts to deploy an NGINX Instance Manager Ubuntu image to AWS
 
 ## Requirements
 
@@ -48,17 +48,17 @@ export TF_VAR_admin_password=xxxxxxxxxxxxxxx
 | Parameter                 | Description                                                                                  | Default             | Required |
 |---------------------------|----------------------------------------------------------------------------------------------|---------------------|----------|
 | admin_password            | _The password for the admin user_                                                            | -                   | Yes      |
-| nms_ami_id                | _AMI Id of the NGINX Management Suite image to use_                                          | -                   | Yes      |
+| nms_ami_id                | _AMI Id of the NGINX Instance Manager image to use_                                          | -                   | Yes      |
 | nginx_ami_id              | _AMI Id of the NGINX image to use_                                                           | -                   | Yes      |
 | agent_instance_group_name | _Agent Instance group name_                                                                  | -                   | Yes      |
 | agent_count               | _The number of agents to deploy_                                                             | -                   | No       |
-| nms_instance_type         | _AWS Instance type for NGINX Management Suite_                                               | `t2.medium`         | No       |
+| nms_instance_type         | _AWS Instance type for NGINX Instance Manager_                                               | `t2.medium`         | No       |
 | nginx_instance_type       | _AWS Instance type for the NGINX instances Instance_                                         | `t3.micro`          | No       |
 | aws_region                | _Region to deploy instance_                                                                  | `us-west-1`         | No       |
 | license_file_path         | _The path to the NGINX API Connectivity Manger license file_                                 | -                   | Yes      |
 | ssh_user                  | _User account name allowed access via ssh._                                                  | `ubuntu`            | No       |
 | ssh_pub_key               | _Path to the ssh pub key that will be used for sshing into the host_                         | `~/.ssh/id_rsa.pub` | No       |
-| mgmt_cidr_blocks          | _List of CIDR blocks to allow access to NGINX Management Suite UI._                          | -                   | No       |
+| mgmt_cidr_blocks          | _List of CIDR blocks to allow access to NGINX Instance Manager UI._                          | -                   | No       |
 |                           | _Add the ip of the host you are running the terraform to access while applying the license._ |                     |          |
 | dataplane_cidr_blocks     | _List of CIDR blocks to allow access to the dataplane instances._                            | -                   | No       |
 | disk_config               | _Map of size and device paths for attached storage_                                          | See example file    | Yes      |

--- a/terraform/standalone/nms/aws/README.md
+++ b/terraform/standalone/nms/aws/README.md
@@ -1,6 +1,6 @@
-# AWS NGINX Management Suite Image Deployment
+# AWS NGINX Instance Manager Image Deployment
 
-This directory contains templates and scripts to deploy an NGINX Management Suite Ubuntu image to AWS
+This directory contains templates and scripts to deploy an NGINX Instance Manager Ubuntu image to AWS
 
 ## Requirements
 
@@ -56,7 +56,7 @@ export TF_VAR_admin_password=xxxxxxxxxxxxxxx
 | ssh_user             | _User account name allowed access via ssh._                                                 | `ubuntu`            | No       |
 | ssh_pub_key          | _Path to the ssh pub key that will be used for sshing into the host_                        | `~/.ssh/id_rsa.pub` | No       |
 | subnet_id            | _ID of subnet to use for this instance. If unset, then a new vpc & subnet will be created._ | -                   | No       |
-| incoming_cidr_blocks | _List of custom CIDR blocks to allow access to NGINX Management Suite UI._                  | -                   | No       |
+| incoming_cidr_blocks | _List of custom CIDR blocks to allow access to NGINX Instance Manager UI._                  | -                   | No       |
 | disk_config          | _Map of size and device paths for attached storage_                                         | See example file    | Yes      |
 | tags                 | _Map of tags to apply to resulting AWS resources_                                           | `{}`                | No       |
 

--- a/terraform/standalone/nms/azure/README.md
+++ b/terraform/standalone/nms/azure/README.md
@@ -1,6 +1,6 @@
-# Azure NGINX Management Suite Image Deployment
+# Azure NGINX Instance Manager Image Deployment
 
-This directory contains templates and scripts to deploy an NGINX Management Suite Ubuntu image to Azure
+This directory contains templates and scripts to deploy an NGINX Instance Manager Ubuntu image to Azure
 
 ## Requirements
 
@@ -65,7 +65,7 @@ export TF_VAR_admin_password=xxxxxxxxxxxxxxx
 | -------------------- | -------------------------------------------------------------------------- | ------------------- | -------- |
 | admin_password       | _The password for the created `admin_user`_                                | -                   | Yes      |
 | image_name           | _Image being deployed_                                                     | -                   | Yes      |
-| incoming_cidr_blocks | _List of custom CIDR blocks to allow access to NGINX Management Suite UI._ | -                   | No       |
+| incoming_cidr_blocks | _List of custom CIDR blocks to allow access to NGINX Instance Manager UI._ | -                   | No       |
 | instance_type        | _Azure compute instance type to use._                                      | `Standard_B2s`      | No       |
 | resource_group_name  | _The Azure resource group ID to use._                                      | -                   | Yes      |
 | ssh_pub_key          | _Path to the ssh pub key that will be used for sshing into the host_       | `~/.ssh/id_rsa.pub` | No       |

--- a/terraform/standalone/nms/gcp/README.md
+++ b/terraform/standalone/nms/gcp/README.md
@@ -1,6 +1,6 @@
-# GCP NGINX Management Suite Image Deployment
+# GCP NGINX Instance Manager Image Deployment
 
-This directory contains templates and scripts to deploy an NGINX Management Suite Ubuntu image to GCP
+This directory contains templates and scripts to deploy an NGINX Instance Manager Ubuntu image to GCP
 
 ## Requirements
 
@@ -52,7 +52,7 @@ export TF_VAR_admin_password=xxxxxxxxxxxxxxx
 | admin_password       | _The password for the created `admin_user`_                                | -                   | Yes      |
 | image_name           | _Image being deployed_                                                     | -                   | Yes      |
 | network_name         | _GCP VPC network with port 22/443 access_                                  | -                   | Yes      |
-| incoming_cidr_blocks | _List of custom CIDR blocks to allow access to NGINX Management Suite UI. _| -                   | No       |
+| incoming_cidr_blocks | _List of custom CIDR blocks to allow access to NGINX Instance Manager UI. _| -                   | No       |
 | instance_type        | _GCP compute instance type to use._                                        | `e2-micro`          | No       |
 | project_id           | _The GCP project ID to use._                                               | -                   | Yes      |
 | ssh_pub_key          | _Path to the ssh pub key that will be used for sshing into the host_       | `~/.ssh/id_rsa.pub` | No       |

--- a/terraform/standalone/nms/vsphere/README.md
+++ b/terraform/standalone/nms/vsphere/README.md
@@ -1,6 +1,6 @@
-# vSphere NGINX Management Suite Machine Template Deployment
+# vSphere NGINX Instance Manager Machine Template Deployment
 
-This directory contains templates and scripts to deploy an NGINX Management Suite Ubuntu Virtual Machine to vSphere.
+This directory contains templates and scripts to deploy an NGINX Instance Manager Ubuntu Virtual Machine to vSphere.
 
 ## Requirements
 


### PR DESCRIPTION
### Proposed changes

This change includes changes to the README files. References to NGINX Management Suite (NMS) have been changed to NGINX Instance Manager (NIM). No code has been changed. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nms-iac/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nms-iac/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nms-iac/blob/main/CHANGELOG.md))
